### PR TITLE
Xcode code snippet

### DIFF
--- a/.xcode/EnumPropertyWithAssociatedData.xml
+++ b/.xcode/EnumPropertyWithAssociatedData.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>IDECodeSnippetCompletionPrefix</key>
+  <string>enumproperty</string>
+  <key>IDECodeSnippetCompletionScopes</key>
+  <array>
+    <string>All</string>
+  </array>
+  <key>IDECodeSnippetContents</key>
+  <string>  var &lt;#propertyName#&gt;: &lt;#AssociatedType#&gt;? {
+    get {
+      guard case let .&lt;#propertyName#&gt;(value) = self else { return nil }
+      return value
+    }
+    set {
+      guard case .&lt;#propertyName#&gt; = self, let newValue = newValue else { return }
+      self = .&lt;#propertyName#&gt;(newValue)
+    }
+  }</string>
+  <key>IDECodeSnippetIdentifier</key>
+  <string>2F08B62F-9E64-40F5-9004-E779C21A7C40</string>
+  <key>IDECodeSnippetLanguage</key>
+  <string>Xcode.SourceCodeLanguage.Swift</string>
+  <key>IDECodeSnippetSummary</key>
+  <string></string>
+  <key>IDECodeSnippetTitle</key>
+  <string>Enum Property with associated data</string>
+  <key>IDECodeSnippetUserSnippet</key>
+  <true/>
+  <key>IDECodeSnippetVersion</key>
+  <integer>0</integer>
+</dict>
+</plist>

--- a/.xcode/EnumPropertyWithAssociatedData.xml
+++ b/.xcode/EnumPropertyWithAssociatedData.xml
@@ -9,7 +9,7 @@
     <string>All</string>
   </array>
   <key>IDECodeSnippetContents</key>
-  <string>  var &lt;#propertyName#&gt;: &lt;#AssociatedType#&gt;? {
+  <string>  public var &lt;#propertyName#&gt;: &lt;#AssociatedType#&gt;? {
     get {
       guard case let .&lt;#propertyName#&gt;(value) = self else { return nil }
       return value

--- a/README.md
+++ b/README.md
@@ -151,6 +151,20 @@ Running `generate-enum-properties` is idempotent: it will only insert properties
 
 Now you may be wondering: _why not generate extensions that can be hidden away in another file?_ Unfortunately, this is problematic for enums that depend on types that need to be imported and types that are nested. By inlining enum properties, we can ensure that every associated value's type is in scope.
 
+## Xcode Code Snippets
+
+If you or your team are not yet ready to use code generation in your code base, don't let that stop you from using enum properties! They are too useful to give up. Instead you can use our Xcode code snippet with a little bit of manual work to allow easy creation of enum properties in your code base:
+
+![Sep-25-2019 09-45-56](https://user-images.githubusercontent.com/135203/65606830-8829fa00-df79-11e9-86f2-d3b3ff5f39fe.gif)
+
+To install just add all of the code snippets in the [.xcode](.xcode) directory to the following directory:
+
+```
+~/Library/Developer/Xcode/UserData/CodeSnippets/
+```
+
+For more information about Xcode code snippets check out this informative NSHipster [article](https://nshipster.com/xcode-snippets/).
+
 ## Installation
 
 ### Homebrew


### PR DESCRIPTION
Added an Xcode code snippet for the simplest use case of enum properties. We could also add one for cases with no associated data too.